### PR TITLE
Add linux platform on Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,6 +119,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   bridgetown (~> 1.0.0.beta3)


### PR DESCRIPTION
When I installed the repo on my machine and ran bundle this line
appeared on the Gemfile.lock, I'm wondering if is it important or not.

Do you know if should this be included?
if don't, please fell free to close it.

BTW, what is the path of this project? Do you have any idea? I'd like to
be part of it :rocket:

This is needed
